### PR TITLE
Apply FFL company-name suffix in handleSelect

### DIFF
--- a/src/components/Dealer/Locator.tsx
+++ b/src/components/Dealer/Locator.tsx
@@ -41,6 +41,7 @@ export default class Locator extends React.PureComponent<LocatorProps, LocatorSt
       activeDealer: null,
       showMap: false,
       dealersHeight: 0,
+      appendFflToCompanyName: false,
     };
 
     this.dealersRef = React.createRef();
@@ -106,6 +107,7 @@ export default class Locator extends React.PureComponent<LocatorProps, LocatorSt
     })
     .then(res => res.json())
     .then(data => {
+      this.setState({ appendFflToCompanyName: !!data.append_ffl_to_company_name });
       if (data.announcement) {
         this.setState({ announcement: data.announcement }, () => {
           this.updateDealersHeight();
@@ -147,6 +149,7 @@ export default class Locator extends React.PureComponent<LocatorProps, LocatorSt
               activeDealer={this.state.activeDealer}
               handleActiveDealer={this.handleActiveDealer}
               selectDealer={selectDealer}
+              appendFflToCompanyName={this.state.appendFflToCompanyName}
             />
           </div>
           <DealerMap
@@ -158,7 +161,8 @@ export default class Locator extends React.PureComponent<LocatorProps, LocatorSt
             showMap={this.state.showMap}
             setShowMap={(show) => this.setState({ showMap: show })}
             dealersHeight={this.state.dealersHeight}
-            loading={this.state.loading} />
+            loading={this.state.loading}
+            appendFflToCompanyName={this.state.appendFflToCompanyName} />
         </div>
       </div>
     );

--- a/src/components/Dealer/components/Locator/DealerCard.tsx
+++ b/src/components/Dealer/components/Locator/DealerCard.tsx
@@ -7,7 +7,7 @@ import { DealerCardProps } from './types';
 import { handleSelect } from '../LocatorMap/utils';
 
 export default function DealerCard(props: DealerCardProps): JSX.Element {
-  const { dealer, index, handleActiveDealer, setActiveDealer, selectDealer } = props;
+  const { dealer, index, handleActiveDealer, setActiveDealer, selectDealer, appendFflToCompanyName } = props;
   let isActive = dealer === setActiveDealer;
   const cardRef = useRef<HTMLDivElement>(null);
 
@@ -65,7 +65,7 @@ export default function DealerCard(props: DealerCardProps): JSX.Element {
             <div className='h-12 flex items-center justify-center overflow-hidden mt-1'>
               <button
                 className={`relative px-4 py-2 rounded block w-full ${dealer.preferred ? 'bg-secondary' : 'bg-primary hover:bg-hover'}`}
-                onClick={(e) => { e.stopPropagation(); handleSelect(dealer, selectDealer); }}>
+                onClick={(e) => { e.stopPropagation(); handleSelect(dealer, selectDealer, { appendFflToCompanyName }); }}>
                 <span className={`absolute inset-0 rounded ${dealer.preferred ? 'bg-secondary' : 'bg-primary hover:bg-hover'}`}></span>
                 <span className="relative font-bold text-white">SELECT</span>
               </button>

--- a/src/components/Dealer/components/Locator/DealerList.tsx
+++ b/src/components/Dealer/components/Locator/DealerList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import DealerCard from './DealerCard';
 import { DealerListProps } from './types';
 
-const DealerList: React.FC<DealerListProps> = ({ dealersRef, dealers, loading, searched, currentLocation, activeDealer, handleActiveDealer, selectDealer }) => {
+const DealerList: React.FC<DealerListProps> = ({ dealersRef, dealers, loading, searched, currentLocation, activeDealer, handleActiveDealer, selectDealer, appendFflToCompanyName }) => {
   return (
     <div ref={dealersRef} className="scrollbar flex-1 overflow-y-auto snap-y locator-modal-content mb-12 lg:mb-0">
       {!loading && dealers.map((dealer, index) => (
@@ -13,6 +13,7 @@ const DealerList: React.FC<DealerListProps> = ({ dealersRef, dealers, loading, s
           setActiveDealer={activeDealer}
           handleActiveDealer={handleActiveDealer}
           selectDealer={selectDealer}
+          appendFflToCompanyName={appendFflToCompanyName}
         />
       ))}
       {searched && !loading && (

--- a/src/components/Dealer/components/Locator/DealerMap.tsx
+++ b/src/components/Dealer/components/Locator/DealerMap.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import LocatorMap from './../LocatorMap/LocatorMap';
 import { DealerMapProps } from './types';
 
-const DealerMap: React.FC<DealerMapProps> = ({ googleMapsApiKey, dealers, selectDealer, activeDealer, handleActiveDealer, showMap, setShowMap, dealersHeight, loading }) => {
+const DealerMap: React.FC<DealerMapProps> = ({ googleMapsApiKey, dealers, selectDealer, activeDealer, handleActiveDealer, showMap, setShowMap, dealersHeight, loading, appendFflToCompanyName }) => {
   return (
     <div id="dealersMap" className={`absolute lg:static w-full bottom-0 lg:flex-1 transition-all duration-200 locator-modal-map`} style={{ height: showMap ? `${dealersHeight + 42}px` : "42px" }}>
       <div className="lg:hidden h-12 flex items-center justify-center font-bold bg-hover text-white cursor-pointer" onClick={() => setShowMap(!showMap)}>
@@ -26,6 +26,7 @@ const DealerMap: React.FC<DealerMapProps> = ({ googleMapsApiKey, dealers, select
           setActiveDealer={handleActiveDealer}
           activeDealer={activeDealer}
           showMap={showMap}
+          appendFflToCompanyName={appendFflToCompanyName}
         />
       </div>
     </div>

--- a/src/components/Dealer/components/Locator/types.tsx
+++ b/src/components/Dealer/components/Locator/types.tsx
@@ -8,6 +8,7 @@ export interface DealerMapProps {
   setShowMap: (show: boolean) => void;
   dealersHeight: number;
   loading: boolean;
+  appendFflToCompanyName?: boolean;
 }
 
 interface Dealer {
@@ -30,6 +31,7 @@ export interface DealerCardProps {
   handleActiveDealer: (dealer: Dealer) => void;
   setActiveDealer: Dealer;
   selectDealer: (dealer: Dealer) => void;
+  appendFflToCompanyName?: boolean;
 }
 
 export interface DealerListProps {
@@ -41,6 +43,7 @@ export interface DealerListProps {
   activeDealer: any;
   handleActiveDealer: (dealer: any) => void;
   selectDealer: (dealer: any) => void;
+  appendFflToCompanyName?: boolean;
 }
 
 interface Fee {

--- a/src/components/Dealer/components/LocatorMap/LocatorMap.tsx
+++ b/src/components/Dealer/components/LocatorMap/LocatorMap.tsx
@@ -5,7 +5,7 @@ import { mapConfigs } from './constants';
 import { LocatorMapProps } from './types';
 import formatPhoneNumber from '../../PhoneNumberFormatter'
 
-const LocatorMap = ({ apiKey, dealers, selectDealer, setActiveDealer, activeDealer, showMap }: LocatorMapProps) => {
+const LocatorMap = ({ apiKey, dealers, selectDealer, setActiveDealer, activeDealer, showMap, appendFflToCompanyName }: LocatorMapProps) => {
   const [state, setState] = useState({
     activeMarker: null,
     activeDealer: '',
@@ -50,6 +50,7 @@ const LocatorMap = ({ apiKey, dealers, selectDealer, setActiveDealer, activeDeal
           setActiveDealer={setActiveDealer}
           showMap={showMap}
           activeDealer={activeDealer}
+          appendFflToCompanyName={appendFflToCompanyName}
         />
       </Map>
     </APIProvider>

--- a/src/components/Dealer/components/LocatorMap/Markers.tsx
+++ b/src/components/Dealer/components/LocatorMap/Markers.tsx
@@ -17,7 +17,7 @@ const createSvgMarker = (dealer: DealerProps) => {
   };
 };
 
-const Markers = ({ dealers, prevDealersRef, state, setState, selectDealer, setActiveDealer, showMap, activeDealer}: MarkersProps) => {
+const Markers = ({ dealers, prevDealersRef, state, setState, selectDealer, setActiveDealer, showMap, activeDealer, appendFflToCompanyName }: MarkersProps) => {
   const map = useMap();
 
   const fitMapToBounds = (map: google.maps.Map, dealers: DealerProps[], prevDealersRef: React.MutableRefObject<any[]>) => {
@@ -98,7 +98,7 @@ const Markers = ({ dealers, prevDealersRef, state, setState, selectDealer, setAc
                 <div className='h-12 flex items-center justify-center overflow-hidden'>
                   <button
                     className={`relative px-4 py-2 rounded block w-full ${state.activeDealer.preferred ? 'bg-secondary' : 'bg-primary hover:bg-hover'}`}
-                    onClick={() => handleSelect(state.activeDealer, selectDealer)}>
+                    onClick={() => handleSelect(state.activeDealer, selectDealer, { appendFflToCompanyName })}>
                     <span className={`absolute inset-0 rounded ${state.activeDealer.preferred ? 'bg-secondary' : 'bg-primary hover:bg-hover'}`}></span>
                     <span className="relative z-10 font-bold text-white">SELECT</span>
                   </button>

--- a/src/components/Dealer/components/LocatorMap/types.ts
+++ b/src/components/Dealer/components/LocatorMap/types.ts
@@ -5,6 +5,7 @@ export interface LocatorMapProps {
   setActiveDealer: (dealer: any) => void;
   showMap: boolean;
   activeDealer: any;
+  appendFflToCompanyName?: boolean;
 }
 
 export interface MarkersProps {
@@ -16,6 +17,7 @@ export interface MarkersProps {
   setActiveDealer: any;
   showMap: any;
   activeDealer: any;
+  appendFflToCompanyName?: boolean;
 }
 
 export interface DealerProps {

--- a/src/components/Dealer/components/LocatorMap/utils.test.ts
+++ b/src/components/Dealer/components/LocatorMap/utils.test.ts
@@ -1,0 +1,49 @@
+import { handleSelect } from './utils';
+
+const dealerFixture = () => ({
+  id: 1,
+  business_name: 'ACME Guns',
+  license: '1-23-456',
+  phone_number: '5555551234',
+  premise_street: '100 Main St',
+  premise_city: 'Lexington',
+  premise_state: 'KY',
+  premise_zip: '40507',
+  uuid: 'abc-123',
+});
+
+describe('handleSelect - company field', () => {
+  it('emits raw business_name as company by default', () => {
+    const selectDealer = jest.fn();
+
+    handleSelect(dealerFixture(), selectDealer);
+
+    expect(selectDealer).toHaveBeenCalledTimes(1);
+    expect(selectDealer.mock.calls[0][0].company).toBe('ACME Guns');
+  });
+
+  it('emits raw business_name when appendFflToCompanyName is false', () => {
+    const selectDealer = jest.fn();
+
+    handleSelect(dealerFixture(), selectDealer, { appendFflToCompanyName: false });
+
+    expect(selectDealer.mock.calls[0][0].company).toBe('ACME Guns');
+  });
+
+  it('appends the FFL license when appendFflToCompanyName is true', () => {
+    const selectDealer = jest.fn();
+
+    handleSelect(dealerFixture(), selectDealer, { appendFflToCompanyName: true });
+
+    expect(selectDealer.mock.calls[0][0].company).toBe('ACME Guns - 1-23-456');
+  });
+
+  it('does not change addressFormatted (license is already there)', () => {
+    const selectDealer = jest.fn();
+
+    handleSelect(dealerFixture(), selectDealer, { appendFflToCompanyName: true });
+
+    const payload = selectDealer.mock.calls[0][0];
+    expect(payload.addressFormatted).toContain('ACME Guns | 1-23-456');
+  });
+});

--- a/src/components/Dealer/components/LocatorMap/utils.ts
+++ b/src/components/Dealer/components/LocatorMap/utils.ts
@@ -1,12 +1,19 @@
 import formatPhoneNumber from './../../PhoneNumberFormatter';
 
-export const handleSelect = (dealer: any, selectDealer: any) => {
+export const handleSelect = (
+  dealer: any,
+  selectDealer: any,
+  options: { appendFflToCompanyName?: boolean } = {},
+) => {
   const formattedDealerPhoneNumber = formatPhoneNumber({ phoneNumber: dealer.phone_number });
+  const company = options.appendFflToCompanyName
+    ? `${dealer.business_name} - ${dealer.license}`
+    : dealer.business_name;
 
   selectDealer({
     id: dealer.id,
     phone: formattedDealerPhoneNumber,
-    company: dealer.business_name,
+    company,
     address1: dealer.premise_street,
     address2: '',
     addressFormatted: `${dealer.business_name} | ${dealer.license}<br/>${formattedDealerPhoneNumber}<br/>${dealer.premise_street}<br/>${dealer.premise_city}, ${dealer.premise_state} ${dealer.premise_zip} / United States`,


### PR DESCRIPTION
Reads append_ffl_to_company_name from the existing /store-front/api/stores/ fetch in Locator.tsx and threads it through DealerList/DealerMap to both handleSelect call sites. When enabled, handleSelect emits the address payload's company field as "<business_name> - <license>"; the dealer-picker UI keeps rendering raw business_name.